### PR TITLE
Cost Explorer - Need to add X-Amz-Target header

### DIFF
--- a/aws.js
+++ b/aws.js
@@ -76,6 +76,7 @@ var AWS = (function() {
       var signedHeaders = "";
       headers["Host"] = host;
       headers["X-Amz-Date"] = dateStringFull;
+      headers["X-Amz-Target"] = action;
       Object.keys(headers).sort(function(a,b){return a<b?-1:1;}).forEach(function(h, index, ordered) {
         canonHeaders += h.toLowerCase() + ":" + headers[h] + "\n";
         signedHeaders += h.toLowerCase() + ";";


### PR DESCRIPTION
Hi,

Thanks for this script! Saved me a lot of time and works perfect. 

I have made a small change; added the "**X-Amz-Target**" header necessary to use the Cost Explorer Service. So far I have tested, this header can always be added. 

See also: https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetCostAndUsage.html 

The extra header Content-Type (_"Content-Type":"application/x-amz-json-1.1"_) was also needed to get the Cost Explorer Service to work, but that header should only be added as an extra header option, since it can break other requests.

For adding the "X-Amz-Target" I did not find any disadvantages or breaking request. So I think the best way is to add this header by default.

Thanks in advance,
Frank Zomerdijk