### PR TITLE
Strictly adhere to RFC3986 for URI encoding

### DIFF
--- a/aws.js
+++ b/aws.js
@@ -65,7 +65,7 @@ var AWS = (function() {
         query = "Action="+action;
         if(params) {
           Object.keys(params).sort(function(a,b) { return a<b?-1:1; }).forEach(function(name) {
-            query += "&"+name+"="+encodeURIComponent(params[name]);
+            query += "&"+name+"="+fixedEncodeURIComponent(params[name]);
           });
         }
         request = "https://"+host+uri+"?"+query;
@@ -196,4 +196,18 @@ var AWS = (function() {
 
       return window.Crypto;
   }
+
+    /**
+     * Strictly adhere to RFC3986 for URI encoding
+     *
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+     *
+     * @param str
+     * @returns {string}
+     */
+    function fixedEncodeURIComponent(str) {
+        return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
+            return '%' + c.charCodeAt(0).toString(16);
+        });
+    }
 })();


### PR DESCRIPTION
First, let me thank you for writing this script. It works great to perform AWS calls from within our Google Scripts.

There is a slight issue though with sending emails through SES. Sending emails with characters like () cause a signature mismatch as `encodeURIComponent` apparently doesn't strictly adhere RFC3986. I fixed this by using `fixedEncodeURIComponent` as suggested on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent

Can be tested by sending an email through SES:
```javascript
AWS.AWS.request('email', 'eu-west-1', 'SendEmail', {
    'Source': 'email@addres.com',
    'Destination.ToAddress.member.1': 'email@address.com',
    'Message.Subject.Data': 'Subject',
    'Message.Body.Text.Data': 'Woop, it works! ()'
}, 'GET');
```